### PR TITLE
retry module of llm

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,11 +53,8 @@ peacebot-ai/
 │ │ ├── logger_config.py # JSON-based structured logging
 │ │ ├── retry_utils.py # Retry & exponential backoff logic
 │ │ └── init.py
-│ ├── templates/
-│ │ └── index.html # Frontend chat interface
 │ ├── static/
-│ │ ├── css/
-│ │ │ └── style.css
+│ │ ├── index.html # Frontend chat interface
 │ │ └── js/
 │ │ └── script.js
 │ └── init.py
@@ -87,7 +84,7 @@ source .venv/bin/activate
 ```
 ### 2️⃣ Install dependencies
 ```bash
-pip install -r requirements.txt
+pip install -r requirement.txt
 ```
 ### 3️⃣ Configure your API key
 **Option 1 — Using Environment Variable**

--- a/src/peacebot.py
+++ b/src/peacebot.py
@@ -7,6 +7,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from utils.config_loader import get
 from utils.logger_config import get_logger
+from utils.retry_utils import retry
 
 # ---------------------------------------------------------------------------
 # Logger Setup
@@ -136,6 +137,7 @@ class PeacebotResponder:
         logger.debug("Using local rule-based response generation.")
         return self._generate_locally(sanitized_message)
 
+    @retry(max_retries=3, base_delay=2)
     def _generate_with_openai(self, prompt: str) -> str:
         """Generate response using OpenAI API."""
         model = os.getenv(

--- a/utils/retry_utils.py
+++ b/utils/retry_utils.py
@@ -1,0 +1,32 @@
+# utils/retry_utils.py
+import time
+import functools
+from utils.logger_config import get_logger
+
+logger = get_logger("peacebot.retry")
+
+def retry(max_retries=5, base_delay=1, exceptions=(Exception,)):
+    """Generic retry decorator with exponential backoff and structured logging."""
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            delay = base_delay
+            for attempt in range(1, max_retries + 1):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as e:
+                    if attempt < max_retries:
+                        logger.warning(
+                            f"Retry {attempt}/{max_retries} for {func.__name__} after error: {e}",
+                            extra={"function": func.__name__, "attempt": attempt, "delay": delay}
+                        )
+                        time.sleep(delay)
+                        delay *= 2  # Exponential backoff
+                    else:
+                        logger.error(
+                            f"All {max_retries} retries failed for {func.__name__}",
+                            extra={"function": func.__name__, "error": str(e)}
+                        )
+                        raise
+        return wrapper
+    return decorator


### PR DESCRIPTION
Closes : #20 

# Why the Retry Decorator Is Needed  

## Problem  

Sometimes, when your chatbot talks to an external API like OpenAI, things can go wrong, but not because your code is broken. It might just be:  
- A temporary internet or network issue  
- The API being overloaded or rate-limited  
- A random server timeout  

If your code doesn’t handle these small hiccups, the entire chatbot can crash after a single failed request. That’s a bad user experience.  

---

## Solution - The `@retry` Decorator  

The `@retry` decorator is a simple safety net.  
It automatically **retries** a function when it fails, giving it a few more chances before giving up.  

For example:  

```python
@retry(max_retries=3, base_delay=2)
def _generate_with_openai(...):
    # tries to call the OpenAI API
```

Here’s what happens step by step:  

1. The function runs normally.  
2. If it fails, the decorator catches the error and logs something like:  
   ```
   Retry 1/3 after error: TimeoutError
   ```  
3. It waits 2 seconds, then tries again.  
4. If it fails again, it waits 4 seconds (double the last wait).  
5. After 3 failed attempts, it logs an error and raises the exception so you can see what went wrong.  

This pattern of **increasing wait times** between retries is called *exponential backoff*, it helps reduce strain on the API server.  

---

## How It Works (Simplified Code)  

Here’s the retry decorator in simple form:  

```python
def retry(max_retries=5, base_delay=1, exceptions=(Exception,)):
    def decorator(func):
        def wrapper(*args, **kwargs):
            delay = base_delay
            for attempt in range(1, max_retries + 1):
                try:
                    return func(*args, **kwargs)
                except exceptions as e:
                    if attempt < max_retries:
                        logger.warning(f"Retry {attempt}/{max_retries} after error: {e}")
                        time.sleep(delay)
                        delay *= 2  # Wait longer each time
                    else:
                        logger.error(f"All {max_retries} retries failed")
                        raise
        return wrapper
    return decorator
```

---

## Why This Is Good Practice  

- Prevents random API errors from crashing your chatbot  
- Gives the system a chance to recover automatically  
- Makes your logs easier to understand when debugging  
- Keeps your code more resilient and user-friendly  

In short, the retry decorator makes your chatbot **patient, reliable, and professional**, even when the APIs it talks to are having a bad day.
