### PR TITLE
Fix: Update failing test_api_chat_missing_message to reflect API changes

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,7 +17,8 @@ def test_index_get(client):
 def test_api_chat_missing_message(client):
     resp = client.post("/api/chat", json={})
     assert resp.status_code == 400
-    assert "error" in resp.get_json()
+    data = resp.get_json()
+    assert data["type"] == "validation_error"
 
 
 def test_api_chat_normal_message(client):


### PR DESCRIPTION
---
title: "Fix: Update failing `test_api_chat_missing_message` test to reflect API changes"
---

## Description
This PR addresses a failing test in the `test_app.py` test suite caused by a mismatch between the expected API response and the current implementation in `src/App.py`.

The `/api/chat` endpoint was recently updated to return a validation response in the format `{"reply": "...", "type": "validation_error"}` when an empty message is provided. The test was still asserting the presence of an `"error"` key.

This change updates the assertion to verify that the `type` key is `"validation_error"`, matching the updated behavior of the API.

## Changes Made
* **`tests/test_app.py`**: Updated `test_api_chat_missing_message` to check `assert data["type"] == "validation_error"` instead of `assert "error" in resp.get_json()`.

## Testing
* Pulled and built successfully on the `main` branch.
* Ran `pytest tests/` successfully. All 25/25 tests are now passing without errors.

Closes #58 

For:
## NSoC'26