### PR TITLE
fix: include error field in api chat error responses

### DIFF
--- a/src/App.py
+++ b/src/App.py
@@ -124,8 +124,10 @@ def api_chat():
         message = (data.get("message") or "").strip()
 
         if not message:
+            msg = "Please enter a message before sending."
             return jsonify({
-                "reply": "Please enter a message before sending.",
+                "error": msg,
+                "reply": msg,
                 "type": "validation_error"
             }), 400
 
@@ -148,8 +150,10 @@ def api_chat():
 
     except Exception as e:
         logger.exception(f"Error in api_chat: {e}")
+        msg = "Sorry, something went wrong on my side. Please try again later."
         return jsonify({
-            "reply": "Sorry, something went wrong on my side. Please try again later.",
+            "error": msg,
+            "reply": msg,
             "type": "server_error"
         }), 500
 


### PR DESCRIPTION
``` NSoC' 26 ```
## 📄 Description

```Resolves #64 ```
This PR fixes the /api/chat error response contract.

Previously, when message was missing (400) or when an internal exception happened (500), the API returned reply and type but not error.
This update adds a top-level error field for both error paths while keeping reply for backward compatibility with existing frontend behavior.

Motivation:

Align response shape with current test expectations
Improve API consistency for clients handling error responses
---

## 🔗 Related Issues

Link any related issues using the format below.  
This will **auto-close** the issue when merged:

> Fixes #<58r>
---

## 🖼️ Screenshots (if applicable)

N/A (no UI changes)

---

## 🧩 Type of Change

Select the type of change your PR introduces (check all that apply):

- [✅] 🐛 Bug Fix  
- [ ] ✨ New Feature  
- [ ] ⚡ Enhancement / Optimization  
- [ ] 🧰 Refactoring  
- [ ] 🧾 Documentation Update  
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

Before submitting your PR, please confirm the following:

- [✅] I have performed a self-review of my code.  
- [ ] I have commented my code, particularly in hard-to-understand areas.  
- [ ] I have added or updated relevant documentation.  
- [✅] My changes do not break any existing functionality.  
- [✅] I have tested my changes locally and they work as expected.  
- [ ] I have linked all relevant issues (if any).

---

## 💬 Additional Notes (Optional)

Local test run:

```python -m pytest tests/test_app.py::test_api_chat_missing_message -v ``` (passed)

Changed file:  ```src/App.py```  (error response updates for /api/chat).